### PR TITLE
Add bible reference query support

### DIFF
--- a/services/BibleService.ts
+++ b/services/BibleService.ts
@@ -9,6 +9,8 @@ import { Asset } from "expo-asset";
 import { File } from "expo-file-system";
 import { USXParser } from './USXParser';
 import { BookMetadata, ParsedBook } from '../types/usx-types';
+import { BiblePassage } from '../types';
+import { parseBibleReference, formatNormalizedReference } from '../utils/bibleReference';
 
 export interface BibleBook {
   code: string;
@@ -366,6 +368,50 @@ export class BibleService {
       console.error(`Error getting chapter ${bookCode} ${chapterNumber}:`, error);
       return null;
     }
+  }
+
+  /**
+   * Get a passage by Bible reference string (e.g., "Genesis 1:1-2:7", "Mat 5:3-9")
+   */
+  async getPassageByReference(reference: string): Promise<BiblePassage | null> {
+    const parsed = parseBibleReference(reference);
+    if (!parsed) return null;
+
+    const book = await this.loadBook(parsed.bookCode);
+    const startRef = `${parsed.bookCode} ${parsed.startChapter}:${parsed.startVerse}`;
+    const endRef = `${parsed.bookCode} ${parsed.endChapter}:${parsed.endVerse}`;
+
+    const hasRange = typeof (this.parser as any).getVerseRange === 'function';
+    const verses = hasRange
+      ? (this.parser as any).getVerseRange(book, startRef, endRef)
+      : this.fallbackCollectRange(book, parsed.startChapter, parsed.startVerse, parsed.endChapter, parsed.endVerse);
+
+    return {
+      bookCode: parsed.bookCode,
+      startChapter: parsed.startChapter,
+      startVerse: parsed.startVerse,
+      endChapter: parsed.endChapter,
+      endVerse: parsed.endVerse,
+      verses: verses.map((v: any) => ({ number: v.number, text: v.text, reference: v.reference })),
+      reference: formatNormalizedReference(parsed)
+    };
+  }
+
+  private fallbackCollectRange(book: ParsedBook, sc: number, sv: number, ec: number, ev: number) {
+    const results: any[] = [];
+    for (const chapter of book.chapters) {
+      if (chapter.number < sc || chapter.number > ec) continue;
+      if (sc === ec && chapter.number === sc) {
+        results.push(...chapter.verses.filter(v => v.number >= sv && v.number <= ev));
+      } else if (chapter.number === sc) {
+        results.push(...chapter.verses.filter(v => v.number >= sv));
+      } else if (chapter.number === ec) {
+        results.push(...chapter.verses.filter(v => v.number <= ev));
+      } else {
+        results.push(...chapter.verses);
+      }
+    }
+    return results;
   }
 
   /**

--- a/services/BibleService.web.ts
+++ b/services/BibleService.web.ts
@@ -7,8 +7,9 @@
 
 import { Asset } from "expo-asset";
 import { USXParser } from './USXParser';
-import { BibleBook, BibleChapter, BibleVerse, BibleSearchResult } from '../types';
+import { BibleBook, BibleChapter, BibleVerse, BibleSearchResult, BiblePassage } from '../types';
 import { ParsedBook } from '../types/usx-types';
+import { parseBibleReference, formatNormalizedReference } from '../utils/bibleReference';
 
 export class BibleService {
   private parser: USXParser;
@@ -337,6 +338,50 @@ export class BibleService {
       console.error(`Error getting chapter ${bookCode} ${chapterNumber}:`, error);
       return null;
     }
+  }
+
+  /**
+   * Get a passage by Bible reference string (e.g., "Genesis 1:1-2:7", "Mat 5:3-9")
+   */
+  async getPassageByReference(reference: string): Promise<BiblePassage | null> {
+    const parsed = parseBibleReference(reference);
+    if (!parsed) return null;
+
+    const book = await this.loadBook(parsed.bookCode);
+    const startRef = `${parsed.bookCode} ${parsed.startChapter}:${parsed.startVerse}`;
+    const endRef = `${parsed.bookCode} ${parsed.endChapter}:${parsed.endVerse}`;
+
+    const hasRange = typeof (this.parser as any).getVerseRange === 'function';
+    const verses = hasRange
+      ? (this.parser as any).getVerseRange(book, startRef, endRef)
+      : this.fallbackCollectRange(book, parsed.startChapter, parsed.startVerse, parsed.endChapter, parsed.endVerse);
+
+    return {
+      bookCode: parsed.bookCode,
+      startChapter: parsed.startChapter,
+      startVerse: parsed.startVerse,
+      endChapter: parsed.endChapter,
+      endVerse: parsed.endVerse,
+      verses: verses.map((v: any) => ({ number: v.number, text: v.text, reference: v.reference })),
+      reference: formatNormalizedReference(parsed)
+    };
+  }
+
+  private fallbackCollectRange(book: ParsedBook, sc: number, sv: number, ec: number, ev: number) {
+    const results: any[] = [];
+    for (const chapter of book.chapters) {
+      if (chapter.number < sc || chapter.number > ec) continue;
+      if (sc === ec && chapter.number === sc) {
+        results.push(...chapter.verses.filter(v => v.number >= sv && v.number <= ev));
+      } else if (chapter.number === sc) {
+        results.push(...chapter.verses.filter(v => v.number >= sv));
+      } else if (chapter.number === ec) {
+        results.push(...chapter.verses.filter(v => v.number <= ev));
+      } else {
+        results.push(...chapter.verses);
+      }
+    }
+    return results;
   }
 
   /**

--- a/services/__tests__/BibleReference.test.ts
+++ b/services/__tests__/BibleReference.test.ts
@@ -1,0 +1,51 @@
+import { parseBibleReference, resolveBookCode, formatNormalizedReference } from '../../utils/bibleReference';
+
+describe('bibleReference utils', () => {
+  it('resolves common book names and abbreviations', () => {
+    expect(resolveBookCode('Genesis')).toBe('GEN');
+    expect(resolveBookCode('Gen')).toBe('GEN');
+    expect(resolveBookCode('Gn')).toBe('GEN');
+    expect(resolveBookCode('Mat')).toBe('MAT');
+    expect(resolveBookCode('Mt')).toBe('MAT');
+    expect(resolveBookCode('1 Samuel')).toBe('1SA');
+  });
+
+  it('parses single verse references', () => {
+    const p = parseBibleReference('Genesis 1:1');
+    expect(p).not.toBeNull();
+    expect(p!.bookCode).toBe('GEN');
+    expect(p!.startChapter).toBe(1);
+    expect(p!.startVerse).toBe(1);
+    expect(p!.endChapter).toBe(1);
+    expect(p!.endVerse).toBe(1);
+    expect(formatNormalizedReference(p!)).toBe('GEN 1:1');
+  });
+
+  it('parses intra-chapter ranges', () => {
+    const p = parseBibleReference('Mat 5:3-9');
+    expect(p).not.toBeNull();
+    expect(p!.bookCode).toBe('MAT');
+    expect(p!.startChapter).toBe(5);
+    expect(p!.startVerse).toBe(3);
+    expect(p!.endChapter).toBe(5);
+    expect(p!.endVerse).toBe(9);
+    expect(formatNormalizedReference(p!)).toBe('MAT 5:3-9');
+  });
+
+  it('parses cross-chapter ranges', () => {
+    const p = parseBibleReference('Genesis 1:1-2:7');
+    expect(p).not.toBeNull();
+    expect(p!.bookCode).toBe('GEN');
+    expect(p!.startChapter).toBe(1);
+    expect(p!.startVerse).toBe(1);
+    expect(p!.endChapter).toBe(2);
+    expect(p!.endVerse).toBe(7);
+    expect(formatNormalizedReference(p!)).toBe('GEN 1:1-2:7');
+  });
+
+  it('returns null for invalid inputs', () => {
+    expect(parseBibleReference('NotABook 1:1')).toBeNull();
+    expect(parseBibleReference('Genesis')).toBeNull();
+  });
+});
+

--- a/services/__tests__/BibleServiceReference.test.ts
+++ b/services/__tests__/BibleServiceReference.test.ts
@@ -1,0 +1,54 @@
+import { BibleService } from '../BibleService';
+import { USXParser } from '../USXParser';
+
+// Minimal USX sample spanning two chapters with simple verses
+const SAMPLE_USX = `<?xml version="1.0" encoding="utf-8"?>
+<usx version="3.0">
+  <book code="GEN" style="id" />
+  <para style="h">Genesis</para>
+  <para style="toc1">Genesis</para>
+  <para style="toc2">Genesis</para>
+  <para style="toc3">Gen</para>
+  <chapter number="1" style="c" sid="GEN 1" />
+  <para style="p">
+    <verse number="1" style="v" sid="GEN 1:1" />In the beginning... <verse eid="GEN 1:1" />
+    <verse number="2" style="v" sid="GEN 1:2" />The earth was without form... <verse eid="GEN 1:2" />
+  </para>
+  <chapter eid="GEN 1" />
+  <chapter number="2" style="c" sid="GEN 2" />
+  <para style="p">
+    <verse number="1" style="v" sid="GEN 2:1" />Thus the heavens and the earth were finished... <verse eid="GEN 2:1" />
+    <verse number="7" style="v" sid="GEN 2:7" />Then the Lord God formed man... <verse eid="GEN 2:7" />
+  </para>
+  <chapter eid="GEN 2" />
+</usx>`;
+
+describe('BibleService getPassageByReference', () => {
+  it('returns single verse', async () => {
+    const svc = new BibleService();
+    jest.spyOn<any, any>(svc as any, 'loadUSXFile').mockResolvedValue(SAMPLE_USX);
+    const res = await svc.getPassageByReference('Genesis 1:1');
+    expect(res).not.toBeNull();
+    expect(res!.bookCode).toBe('GEN');
+    expect(res!.verses.length).toBe(1);
+    expect(res!.verses[0].reference).toBe('GEN 1:1');
+  });
+
+  it('returns intra-chapter range', async () => {
+    const svc = new BibleService();
+    jest.spyOn<any, any>(svc as any, 'loadUSXFile').mockResolvedValue(SAMPLE_USX);
+    const res = await svc.getPassageByReference('GEN 1:1-2');
+    expect(res).not.toBeNull();
+    expect(res!.verses.map(v => v.reference)).toEqual(['GEN 1:1', 'GEN 1:2']);
+  });
+
+  it('returns cross-chapter range', async () => {
+    const svc = new BibleService();
+    jest.spyOn<any, any>(svc as any, 'loadUSXFile').mockResolvedValue(SAMPLE_USX);
+    const res = await svc.getPassageByReference('Genesis 1:2-2:7');
+    expect(res).not.toBeNull();
+    expect(res!.verses[0].reference).toBe('GEN 1:2');
+    expect(res!.verses[res!.verses.length - 1].reference).toBe('GEN 2:7');
+  });
+});
+

--- a/types/index.ts
+++ b/types/index.ts
@@ -373,6 +373,16 @@ export interface BibleChapter {
   verses: BibleVerse[];
 }
 
+export interface BiblePassage {
+  bookCode: string;
+  startChapter: number;
+  startVerse: number;
+  endChapter: number;
+  endVerse: number;
+  verses: BibleVerse[];
+  reference: string;
+}
+
 export interface BibleSearchResult {
   book: string;
   chapter: number;

--- a/utils/bibleReference.ts
+++ b/utils/bibleReference.ts
@@ -1,0 +1,202 @@
+/**
+ * Bible Reference Utilities
+ *
+ * Provides parsing and normalization for Bible references like:
+ * - "Genesis 1:1-2:7"
+ * - "Gen 1:1-3"
+ * - "Mat 5:3-9"
+ * - "MAT 5:3"
+ */
+
+export interface ParsedBibleReference {
+  bookCode: string;
+  startChapter: number;
+  startVerse: number;
+  endChapter: number;
+  endVerse: number;
+  original: string;
+}
+
+/**
+ * Normalizes a book key for matching in the map
+ */
+function normalizeBookKey(input: string): string {
+  // Remove punctuation, periods, and extra spaces, uppercase everything
+  return input
+    .replace(/\./g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toUpperCase();
+}
+
+/**
+ * Map of various book names/abbreviations to USX/USFX 3-letter book codes
+ * Includes common English names and typical abbreviations.
+ */
+const BOOK_NAME_TO_CODE: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
+
+  function add(code: string, names: string[]) {
+    for (const name of names) {
+      map[normalizeBookKey(name)] = code;
+    }
+  }
+
+  // Old Testament
+  add('GEN', ['GEN', 'GENESIS', 'GEN', 'GN']);
+  add('EXO', ['EXO', 'EXODUS', 'EX', 'EXOD']);
+  add('LEV', ['LEV', 'LEVITICUS', 'LE', 'LV']);
+  add('NUM', ['NUM', 'NUMBERS', 'NU', 'NM']);
+  add('DEU', ['DEU', 'DEUTERONOMY', 'DEUT', 'DT']);
+  add('JOS', ['JOS', 'JOSHUA', 'JOSH']);
+  add('JDG', ['JDG', 'JUDGES', 'JUDG', 'JGS']);
+  add('RUT', ['RUT', 'RUTH']);
+  add('1SA', ['1SA', '1 SAMUEL', '1 SAM', 'I SAMUEL', 'I SAM', '1SM', '1 SA']);
+  add('2SA', ['2SA', '2 SAMUEL', '2 SAM', 'II SAMUEL', 'II SAM', '2SM', '2 SA']);
+  add('1KI', ['1KI', '1 KINGS', '1 KGS', 'I KINGS', 'I KGS', '1 KNGS', '1 KI']);
+  add('2KI', ['2KI', '2 KINGS', '2 KGS', 'II KINGS', 'II KGS', '2 KNGS', '2 KI']);
+  add('1CH', ['1CH', '1 CHRONICLES', '1 CHR', 'I CHRONICLES', 'I CHR', '1 CH']);
+  add('2CH', ['2CH', '2 CHRONICLES', '2 CHR', 'II CHRONICLES', 'II CHR', '2 CH']);
+  add('EZR', ['EZR', 'EZRA']);
+  add('NEH', ['NEH', 'NEHEMIAH']);
+  add('TOB', ['TOB', 'TOBIT', 'TB']);
+  add('JDT', ['JDT', 'JUDITH', 'JUDITH']);
+  add('EST', ['EST', 'ESTHER', 'ESTH']);
+  add('1MA', ['1MA', '1 MACCABEES', '1 MACC']);
+  add('2MA', ['2MA', '2 MACCABEES', '2 MACC']);
+  add('JOB', ['JOB']);
+  add('PSA', ['PSA', 'PSALMS', 'PSALM', 'PS', 'PSS']);
+  add('PRO', ['PRO', 'PROVERBS', 'PROV', 'PRV']);
+  add('ECC', ['ECC', 'ECCLESIASTES', 'ECCL', 'QOH']);
+  add('SNG', ['SNG', 'SONG OF SONGS', 'SONG', 'CANTICLE OF CANTICLES', 'CANTICLES', 'CANT']);
+  add('WIS', ['WIS', 'WISDOM']);
+  add('SIR', ['SIR', 'SIRACH', 'ECCLESIASTICUS']);
+  add('ISA', ['ISA', 'ISAIAH']);
+  add('JER', ['JER', 'JEREMIAH']);
+  add('LAM', ['LAM', 'LAMENTATIONS']);
+  add('BAR_LjeInBar', ['BAR', 'BARUCH']);
+  add('EZK', ['EZK', 'EZEKIEL', 'EZEK']);
+  add('DAN', ['DAN', 'DANIEL']);
+  add('HOS', ['HOS', 'HOSEA']);
+  add('JOL', ['JOL', 'JOEL']);
+  add('AMO', ['AMO', 'AMOS']);
+  add('OBA', ['OBA', 'OBADIAH', 'OBAD']);
+  add('JON', ['JON', 'JONAH']);
+  add('MIC', ['MIC', 'MICAH']);
+  add('NAM', ['NAM', 'NAHUM', 'NAH']);
+  add('HAB', ['HAB', 'HABAKKUK']);
+  add('ZEP', ['ZEP', 'ZEPHANIAH', 'ZEPH']);
+  add('HAG', ['HAG', 'HAGGAI']);
+  add('ZEC', ['ZEC', 'ZECHARIAH', 'ZECH']);
+  add('MAL', ['MAL', 'MALACHI']);
+
+  // New Testament
+  add('MAT', ['MAT', 'MATTHEW', 'MATT', 'MT']);
+  add('MRK', ['MRK', 'MARK', 'MK']);
+  add('LUK', ['LUK', 'LUKE', 'LK']);
+  add('JHN', ['JHN', 'JOHN', 'JN']);
+  add('ACT', ['ACT', 'ACTS', 'ACTS OF THE APOSTLES']);
+  add('ROM', ['ROM', 'ROMANS', 'RM']);
+  add('1CO', ['1CO', '1 CORINTHIANS', '1 COR', 'I CORINTHIANS', 'I COR']);
+  add('2CO', ['2CO', '2 CORINTHIANS', '2 COR', 'II CORINTHIANS', 'II COR']);
+  add('GAL', ['GAL', 'GALATIANS']);
+  add('EPH', ['EPH', 'EPHESIANS']);
+  add('PHP', ['PHP', 'PHILIPPIANS', 'PHIL']);
+  add('COL', ['COL', 'COLOSSIANS']);
+  add('1TH', ['1TH', '1 THESSALONIANS', '1 THESS', 'I THESSALONIANS', 'I THESS']);
+  add('2TH', ['2TH', '2 THESSALONIANS', '2 THESS', 'II THESSALONIANS', 'II THESS']);
+  add('1TI', ['1TI', '1 TIMOTHY', '1 TIM', 'I TIMOTHY', 'I TIM']);
+  add('2TI', ['2TI', '2 TIMOTHY', '2 TIM', 'II TIMOTHY', 'II TIM']);
+  add('TIT', ['TIT', 'TITUS']);
+  add('PHM', ['PHM', 'PHILEMON', 'PHLM']);
+  add('HEB', ['HEB', 'HEBREWS']);
+  add('JAS', ['JAS', 'JAMES', 'JAS']);
+  add('1PE', ['1PE', '1 PETER', '1 PET', 'I PETER', 'I PET']);
+  add('2PE', ['2PE', '2 PETER', '2 PET', 'II PETER', 'II PET']);
+  add('1JN', ['1JN', '1 JOHN', '1 JN', 'I JOHN', 'I JN']);
+  add('2JN', ['2JN', '2 JOHN', '2 JN', 'II JOHN', 'II JN']);
+  add('3JN', ['3JN', '3 JOHN', '3 JN', 'III JOHN', 'III JN']);
+  add('JUD', ['JUD', 'JUDE']);
+  add('REV', ['REV', 'REVELATION', 'APOCALYPSE', 'RV']);
+
+  return map;
+})();
+
+/**
+ * Resolve a book code (e.g., GEN) from a name or code string.
+ */
+export function resolveBookCode(book: string): string | null {
+  const key = normalizeBookKey(book);
+  if (BOOK_NAME_TO_CODE[key]) return BOOK_NAME_TO_CODE[key];
+  // If already a valid 3-letter code present in mapping values, allow it
+  const maybeCode = key;
+  if (BOOK_NAME_TO_CODE[maybeCode]) return BOOK_NAME_TO_CODE[maybeCode];
+  // Try removing spaces (e.g., "1SAMUEL")
+  const noSpace = key.replace(/\s+/g, '');
+  if (BOOK_NAME_TO_CODE[noSpace]) return BOOK_NAME_TO_CODE[noSpace];
+  return null;
+}
+
+/**
+ * Parse a Bible reference string into structured parts.
+ * Supports intra-chapter and cross-chapter ranges.
+ */
+export function parseBibleReference(input: string): ParsedBibleReference | null {
+  if (!input || typeof input !== 'string') return null;
+  const ref = input.replace(/\u2013|\u2014/g, '-') // normalize en dash/em dash
+                   .replace(/\s+/g, ' ')
+                   .trim();
+
+  // Cross-chapter: Book 1:2-3:4
+  let m = ref.match(/^(.*?)\s+(\d+):(\d+)\s*-\s*(?:(\d+):)?(\d+)$/);
+  if (m) {
+    const [, bookName, sc, sv, ecMaybe, ev] = m;
+    const bookCode = resolveBookCode(bookName);
+    if (!bookCode) return null;
+    const startChapter = parseInt(sc, 10);
+    const startVerse = parseInt(sv, 10);
+    const endChapter = ecMaybe ? parseInt(ecMaybe, 10) : startChapter;
+    const endVerse = parseInt(ev, 10);
+    return { bookCode, startChapter, startVerse, endChapter, endVerse, original: ref };
+  }
+
+  // Intra-chapter range: Book 1:2-10
+  m = ref.match(/^(.*?)\s+(\d+):(\d+)\s*-\s*(\d+)$/);
+  if (m) {
+    const [, bookName, sc, sv, ev] = m;
+    const bookCode = resolveBookCode(bookName);
+    if (!bookCode) return null;
+    const startChapter = parseInt(sc, 10);
+    const startVerse = parseInt(sv, 10);
+    const endVerse = parseInt(ev, 10);
+    return { bookCode, startChapter, startVerse, endChapter: startChapter, endVerse, original: ref };
+  }
+
+  // Single verse: Book 1:2
+  m = ref.match(/^(.*?)\s+(\d+):(\d+)$/);
+  if (m) {
+    const [, bookName, sc, sv] = m;
+    const bookCode = resolveBookCode(bookName);
+    if (!bookCode) return null;
+    const startChapter = parseInt(sc, 10);
+    const startVerse = parseInt(sv, 10);
+    return { bookCode, startChapter, startVerse, endChapter: startChapter, endVerse: startVerse, original: ref };
+  }
+
+  return null;
+}
+
+/**
+ * Format a normalized reference string using a book code.
+ */
+export function formatNormalizedReference(parsed: ParsedBibleReference): string {
+  const { bookCode, startChapter, startVerse, endChapter, endVerse } = parsed;
+  if (startChapter === endChapter && startVerse === endVerse) {
+    return `${bookCode} ${startChapter}:${startVerse}`;
+  }
+  if (startChapter === endChapter) {
+    return `${bookCode} ${startChapter}:${startVerse}-${endVerse}`;
+  }
+  return `${bookCode} ${startChapter}:${startVerse}-${endChapter}:${endVerse}`;
+}
+


### PR DESCRIPTION
Add `getPassageByReference` to bible services to support queries by bible reference strings.

This enables the liturgy of the hours to include simple bible references in JSON instead of the full text.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1911175-e572-43cf-bd1e-904f4e2861e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1911175-e572-43cf-bd1e-904f4e2861e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

